### PR TITLE
fixing a bug in the parse method

### DIFF
--- a/src/Facades/JWT.php
+++ b/src/Facades/JWT.php
@@ -116,8 +116,13 @@ class JWT
      */
     public static function parse($token)
     {
+        if(!is_string($token))  {
+            $token = (string)$token;
+        }
+        //dd($token);
+        //dd((new Parser)->parse($token));
         try {
-            return (new Parser())->parse((string)$token);
+            return (new Parser())->parse($token);
         } catch (\Exception $e) {
             throw new JWTException('Unable to parse token', 1, $e);
         }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -151,7 +151,11 @@ class JWTTest extends TestAbstract
         $this->persistence->shouldReceive('save');
         $token = JWT::build($this->fields);
         $token = JWT::add($token, $newData);
+        $stringToken = (string)$token;
+        $parsedToken = JWT::parse($stringToken);
         $this->assertArraySubset($newData, json_decode($token->getClaim('data'), true));
         $this->assertArraySubset($this->fields, json_decode($token->getClaim('data'), true));
+        $this->assertArraySubset($newData, json_decode($parsedToken->getClaim('data'), true));
+        $this->assertArraySubset($this->fields, json_decode($parsedToken->getClaim('data'), true));
     }
 }


### PR DESCRIPTION
bug that error when given something that was already a string